### PR TITLE
Add .macos & bootstrap.sh

### DIFF
--- a/.exports
+++ b/.exports
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Path to your oh-my-zsh installation.
-export ZSH="/Users/younho9/.oh-my-zsh"
+export ZSH="$HOME/.oh-my-zsh"
 
 # This loads nvm & bash_completion
 # See https://github.com/nvm-sh/nvm#git-install
@@ -9,4 +9,4 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
-export GD=/Users/younho9/Google\ Drive/My\ Drive
+export GD="$HOME/Google Drive/My Drive"

--- a/.gitconfig
+++ b/.gitconfig
@@ -30,4 +30,4 @@
 	required = true
 
 [includeIf "gitdir:~/repositories/company/"]
-	path = ~/repositories/company/.gitconfig.company
+	path = ~/.gitconfig.company

--- a/.macos
+++ b/.macos
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-# install homebrew https://brew.sh
+# Install homebrew https://brew.sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 bash brew.sh
 
+# Install node
 echo "installing node (via nvm)"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 
@@ -12,6 +13,8 @@ echo "node --version: $(node --version)"
 echo "npm --version: $(npm --version)"
 
 npm install --global yarn alfred-open-in-vscode
+
+bash bootstrap.sh
 
 # Disable Private Browsing
 defaults write com.google.chrome IncognitoModeAvailability -integer 1

--- a/.macos
+++ b/.macos
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+# install homebrew https://brew.sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+bash brew.sh
+
+echo "installing node (via nvm)"
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+
+echo "node --version: $(node --version)"
+echo "npm --version: $(npm --version)"
+
+npm install --global yarn alfred-open-in-vscode
+
 # Disable Private Browsing
 defaults write com.google.chrome IncognitoModeAvailability -integer 1
 defaults write com.microsoft.edge InPrivateModeAvailability -integer 1

--- a/.macos
+++ b/.macos
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Disable Private Browsing
+defaults write com.google.chrome IncognitoModeAvailability -integer 1
+defaults write com.microsoft.edge InPrivateModeAvailability -integer 1
+defaults write org.mozilla.firefox DisablePrivateBrowsing -integer 1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export DOTFILES_DIR="$HOME/repositories/github/public/dotfiles"
+
+if [ -d $DOTFILES_DIR ]; then
+    cd "$(dirname "${BASH_SOURCE}")";
+    git pull origin main
+else
+    git clone git@github.com:younho9/dotfiles.git $DOTFILES_DIR
+
+    ln -sf "$DOTFILES_DIR/.aliases" "$HOME/.aliases"
+    ln -sf "$DOTFILES_DIR/.exports" "$HOME/.exports"
+    ln -sf "$DOTFILES_DIR/.gitconfig" "$HOME/.gitconfig"
+    ln -sf "$DOTFILES_DIR/.gitconfig.company" "$HOME/.gitconfig.company"
+    ln -sf "$DOTFILES_DIR/.gitignore_global" "$HOME/.gitignore_global"
+    ln -sf "$DOTFILES_DIR/.gitmessage.txt" "$HOME/.gitmessage.txt"
+    ln -sf "$DOTFILES_DIR/.p10k.zsh" "$HOME/.p10k.zsh"
+    ln -sf "$DOTFILES_DIR/.zshrc" "$HOME/.zshrc"
+fi


### PR DESCRIPTION
## Summary

<!-- PR 요약 -->

- .macos: disable private browsing
- .macos: add install brew & node
- .gitconfig: move `.gitconfig.company` to root
- .exports: use `$HOME` alias
- .macos add exec bootstrap.sh
- bootstrap.sh: init bootstrap.sh

## Related Issues

<!--
  관련 이슈 링크

  PR이 머지될 때, 이슈를 닫는 키워드 (close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

  - Issue in the same repository: KEYWORD #ISSUE-NUMBER ex) Closes #10
  - Issue in a different repository:	KEYWORD OWNER/REPOSITORY#ISSUE-NUMBER	ex) Fixes octo-org/octo-repo#100
  - Multiple issues: ex) Resolves #10, resolves #123, resolves octo-org/octo-repo#100

  참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolve #1, #2
